### PR TITLE
docs(cli): drop Init2 mention per review

### DIFF
--- a/content/reference/CLI Commands.md
+++ b/content/reference/CLI Commands.md
@@ -20,9 +20,6 @@ Lex App ships with a `lex` CLI tool for managing your application. Here's every 
 - `--bootstrap` — open the browser bootstrap flow if Keycloak credentials are missing
 - `--skip-client-preflight` — bypass the local Keycloak client safety check when you're intentionally managing that setup yourself
 
-> [!note]
-> `lex Init2` is a newer variant of `lex Init` used by some legacy projects during migration. New projects should use `lex Init`.
-
 ### `lex start` flags
 
 `lex start` wraps the ASGI server. The Quick Start in [[getting started|Getting Started]] uses:
@@ -174,4 +171,5 @@ Get-Content .env | ForEach-Object {
 lex Init
 lex start
 ```
+
 


### PR DESCRIPTION
Per review feedback on #99: `lex Init2` should not be mentioned in the docs. Removes the callout from `reference/CLI Commands.md`.
Targets `docs/audit-2026-05-followups` so it folds into #99 on merge (branch protection blocks direct pushes to the audit branch).